### PR TITLE
Project Directory Layout: Remove patched directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,12 +276,10 @@ docroot
 |   |   |   |-- custom
 |   |   |   |-- dev-tools
 |   |   |   |-- features
-|   |   |   |-- migration
-|   |   |   `-- patched
+|   |   |   `-- migration
 |   |   `-- themes
 |   |       |-- contrib
-|   |       |-- custom
-|   |       `-- patched
+|   |       `-- custom
 |   |-- example.com
 |   |   |-- files
 |   |   `-- inc
@@ -297,7 +295,7 @@ The drush directory allows for command files to be added to the repository in si
 
 The modules directory is further divided into separate sub-directories, this makes reviewing the health of any given Drupal project much simpler. A healthy project will have few modules in contrib or patched and the majority of the sites complexity in contrib.
 
-Modules in the patched directory should always have any patches applied to them checked into the root of that modules directory.
+Patched modules should always have any patches applied to them checked into the root of that modules directory.
 
 When moving modules around the directory structure you will need to use the [registry_rebuild](https://drupal.org/project/registry_rebuild) drush command. Drupal does not expect modules to be moved around underneath it.
 


### PR DESCRIPTION
Hey

I'm suggesting to remove the 'patched' directories, because:
1. Patched modules should be temporary, and a production site does not need to have modules moved around often, just because we want a nicer directory structure. Even if there are only a few instants of breakage, or no breakage at all, registry_rebuild() is not something that you want to run in a production site (unless is there is a good reason for it)
2. A patched module is still a contrib module. When you look for a module, you want to find them for what they are, not for how patched they are at that moment.
3. This code structure potentially exposes unnecessary information, as some paths may be visible (CSS / JS files). Everybody will know you patched Views, for example.
4. Ideally, no modules should be patched. Having a directory like this assumes you will patch / hack.

What is important is that patched modules are properly documented, in a wiki, for example. The documentation should include the link to drupal.org's queue system (or why you didn't put the patch there, if that's the case), explain why you patched, what you tried before, and what are the expectations of having this committed upstream.
You may also want to keep track of lots of other things such us the dev versions of the modules you are using, having up-to-date documentation is the way to go.

I haven't tried that yet, but another way of keeping track of patched modules is with drush make: http://www.acquia.com/blog/drush-experts-technique
